### PR TITLE
add pi-vision-bridge to Utilities

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -228,6 +228,7 @@ Other utility packages.
 - [@code-yeongyu/pi-rules](https://github.com/code-yeongyu/pi-rules) - Auto-discovers rule files like .claude/rules, .cursor/rules, AGENTS.md, etc. `pi install npm:@code-yeongyu/pi-rules`
 - [@ravan08/pi-langfuse](https://github.com/saravananravi08/pi-langfuse-extension) - Langfuse observability, tracking tokens, cost, model, and tool calls. `pi install npm:@ravan08/pi-langfuse`
 - [pi-venice](https://github.com/tunnckoCore/pi-venice) - Venice.AI extension supporting text/image/video models. `pi install npm:pi-venice`
+- [pi-vision-bridge](https://github.com/wuxiangru915/pi-vision-bridge) - Gives text-only models image understanding — a `describe_image` tool plus automatic image-to-text fallback, works with any vision model (Gemini/Qwen-VL/GLM), auto-discovery with fallback. `pi install npm:@wuxiangru/pi-vision-bridge`
 - [@juicesharp/rpiv-i18n](https://pi.dev/packages/@juicesharp/rpiv-i18n) - Localization foundation for rpiv-* extensions. `pi install npm:@juicesharp/rpiv-i18n`
 - [@a5c-ai/babysitter-pi](https://pi.dev/packages/@a5c-ai/babysitter-pi) - AI babysitter extension. `pi install npm:@a5c-ai/babysitter-pi`
 

--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ MCP (Model Context Protocol) 适配 Package，连接外部工具生态。
 - [@code-yeongyu/pi-rules](https://github.com/code-yeongyu/pi-rules) - 自动发现 .claude/rules, .cursor/rules, AGENTS.md 等规则文件。`pi install npm:@code-yeongyu/pi-rules`
 - [@ravan08/pi-langfuse](https://github.com/saravananravi08/pi-langfuse-extension) - Langfuse 可观测性，追踪 token、费用、模型和工具调用。`pi install npm:@ravan08/pi-langfuse`
 - [pi-venice](https://github.com/tunnckoCore/pi-venice) - Venice.AI 扩展，支持文本/图像/视频模型。`pi install npm:pi-venice`
+- [pi-vision-bridge](https://github.com/wuxiangru915/pi-vision-bridge) - 让纯文本模型获得识图能力——`describe_image` 工具 + 粘贴图片自动转文字，支持 Gemini/Qwen-VL/GLM 等任意视觉模型，自动发现并失败回退。`pi install npm:@wuxiangru/pi-vision-bridge`
 - [@juicesharp/rpiv-i18n](https://pi.dev/packages/@juicesharp/rpiv-i18n) - rpiv-* 扩展的本地化基础。`pi install npm:@juicesharp/rpiv-i18n`
 - [@a5c-ai/babysitter-pi](https://pi.dev/packages/@a5c-ai/babysitter-pi) - AI 监护扩展。`pi install npm:@a5c-ai/babysitter-pi`
 


### PR DESCRIPTION
## What

Add [pi-vision-bridge](https://github.com/wuxiangru915/pi-vision-bridge) to the **Utilities** category in both README.md and README.en.md.

## Why

pi-vision-bridge lets text-only models (DeepSeek, Llama, etc.) understand images:
- `describe_image` tool — the agent delegates image analysis to any vision model configured in pi's model registry (Gemini, Qwen-VL, GLM, OpenAI, Ollama), without switching models mid-task.
- Automatic image-to-text fallback for pasted/attached images.
- Auto-discovery of vision models with failure fallback; zero runtime dependencies.

Install: `pi install npm:@wuxiangru/pi-vision-bridge`