### PR TITLE
Add Blue-B/pi-custom-packages to Package Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ Pi 核心不内置 plan mode，用扩展补只读规划。
 - [jayshah5696/pi-agent-extensions](https://github.com/jayshah5696/pi-agent-extensions) - 15+ 扩展集合（sessions, ask_user, handoff, powerline-footer 等）。`pi install git:github.com/jayshah5696/pi-agent-extensions`
 - [pi-toolbox](https://github.com/indydevdan/pi-toolbox) - 17 个扩展 + 11 个主题 + 技能和智能体编排模板的综合工具包。`pi install npm:pi-toolbox`
 - [pi-workstation](https://github.com/marv1nnnnn/pi-workstation) - 9 个手工制作主题（前卫剧场、赛博朋克、葛饰北斋风格等）+ 扩展。`pi install npm:pi-workstation`
+- [Blue-B/pi-custom-packages](https://github.com/Blue-B/pi-custom-packages) - 10 个扩展的 monorepo：会话守护（bash 超时单位纠正、切换模型后重新注入身份）、上下文图片裁剪与会话文件瘦身，以及 WSL 下驱动 Windows 桌面的截屏、鼠标键盘与录屏（winshot, cursor, recordly, verify-gate, gpt-img 等）。`pi install git:github.com/Blue-B/pi-custom-packages`
 
 ---
 


### PR DESCRIPTION
10 个扩展的 monorepo，在 WSL 上日常使用。

主要内容：
- 会话守护：bash 超时单位纠正（模型常传毫秒）、切换模型后重新注入身份
- 上下文治理：裁剪出站请求中的旧图片、瘦身磁盘上的会话文件
- Windows 桌面：WSL 下截屏（可捕获被遮挡窗口并做隐私打码）、鼠标键盘、录屏

已加根 package.json 的 pi 字段，`pi install git:github.com/Blue-B/pi-custom-packages` 一条命令即可安装全部；也可以 clone 后单独安装某一个。MIT，每个包各自带 README，在 pi 0.84 上测试。

按现有格式追加在 Package Collections 末尾。