### PR TITLE
Add pi-vetter to Security & Permission

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -128,6 +128,7 @@ Security and permission control packages.
 - [pi-hooks/permission](https://github.com/prateekmedia/pi-hooks) - Four-tier permission control (Minimal/Low/Medium/High). `pi install npm:pi-hooks`
 - [filter-output](https://github.com/michalvavra/agents) - Automatically captures sensitive values and redacts them before sending to the AI. `pi install git:github.com/michalvavra/agents`
 - [security](https://github.com/michalvavra/agents) - Blocks dangerous commands (e.g., sudo) requiring explicit user approval. `pi install git:github.com/michalvavra/agents`
+- [pi-vetter](https://github.com/jesset/pi-vetter) - Supply-chain vetting before install/update: OSV vulns, sigstore provenance verification, static-pattern and version-diff evidence, ALLOW/ASK/DENY verdicts with the full evidence list, fail-closed on scanner failure. `pi install npm:pi-vetter`
 
 ---
 

--- a/README.en.md
+++ b/README.en.md
@@ -128,7 +128,7 @@ Security and permission control packages.
 - [pi-hooks/permission](https://github.com/prateekmedia/pi-hooks) - Four-tier permission control (Minimal/Low/Medium/High). `pi install npm:pi-hooks`
 - [filter-output](https://github.com/michalvavra/agents) - Automatically captures sensitive values and redacts them before sending to the AI. `pi install git:github.com/michalvavra/agents`
 - [security](https://github.com/michalvavra/agents) - Blocks dangerous commands (e.g., sudo) requiring explicit user approval. `pi install git:github.com/michalvavra/agents`
-- [pi-vetter](https://github.com/jesset/pi-vetter) - Supply-chain vetting before install/update: OSV vulns, sigstore provenance verification, static-pattern and version-diff evidence, ALLOW/ASK/DENY verdicts with the full evidence list, fail-closed on scanner failure. `pi install npm:pi-vetter`
+- [pi-vetter](https://github.com/jesset/pi-vetter) - On-demand supply-chain risk assessment for npm packages via `/vet` and `/vet-install`: OSV advisories, provenance verification, static patterns, and version diffs with ALLOW/ASK/DENY reports. A clean report does not prove safety. `pi install npm:pi-vetter`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ MCP (Model Context Protocol) 适配 Package，连接外部工具生态。
 - [pi-hooks/permission](https://github.com/prateekmedia/pi-hooks) - 四层权限控制（Minimal/Low/Medium/High）。`pi install npm:pi-hooks`
 - [filter-output](https://github.com/michalvavra/agents) - 自动捕获敏感值并在发送给 AI 前编辑。`pi install git:github.com/michalvavra/agents`
 - [security](https://github.com/michalvavra/agents) - 阻止危险命令（如 sudo），需要显式用户批准。`pi install git:github.com/michalvavra/agents`
-- [pi-vetter](https://github.com/jesset/pi-vetter) - 安装/更新前的供应链安全评估：OSV 漏洞、sigstore provenance 验证、静态模式与版本 diff 多路证据，ALLOW/ASK/DENY 判定附完整证据清单，扫描器失败时 fail-closed 封顶 ASK。`pi install npm:pi-vetter`
+- [pi-vetter](https://github.com/jesset/pi-vetter) - npm 插件安装/更新前的供应链风险评估：通过 `/vet`、`/vet-install` 主动检查 OSV 漏洞、发布来源、静态模式与版本差异，报告 ALLOW/ASK/DENY；未发现风险不代表安全。`pi install npm:pi-vetter`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ MCP (Model Context Protocol) 适配 Package，连接外部工具生态。
 - [pi-hooks/permission](https://github.com/prateekmedia/pi-hooks) - 四层权限控制（Minimal/Low/Medium/High）。`pi install npm:pi-hooks`
 - [filter-output](https://github.com/michalvavra/agents) - 自动捕获敏感值并在发送给 AI 前编辑。`pi install git:github.com/michalvavra/agents`
 - [security](https://github.com/michalvavra/agents) - 阻止危险命令（如 sudo），需要显式用户批准。`pi install git:github.com/michalvavra/agents`
+- [pi-vetter](https://github.com/jesset/pi-vetter) - 安装/更新前的供应链安全评估：OSV 漏洞、sigstore provenance 验证、静态模式与版本 diff 多路证据，ALLOW/ASK/DENY 判定附完整证据清单，扫描器失败时 fail-closed 封顶 ASK。`pi install npm:pi-vetter`
 
 ---
 


### PR DESCRIPTION
## What

Adds [pi-vetter](https://github.com/jesset/pi-vetter) to **Security & Permission** in both `README.md` and `README.en.md`.

## Why it fits

pi-vetter covers a gap none of the current security entries address: supply-chain vetting of the *extension packages themselves* before install/update. Pi installs extensions with full user permissions and runs their `postinstall` scripts, while the built-in updater only says "updates exist". pi-vetter evaluates each candidate version against OSV (CVE / GHSA / OpenSSF malicious-package advisories), sigstore provenance verification, static pattern scanning and old-vs-new tarball diff, then reports an ALLOW / ASK / DENY verdict with the full evidence list — fail-closed, so any enabled scanner failure caps the verdict at ASK.

- npm: https://www.npmjs.com/package/pi-vetter
- pi.dev directory: https://pi.dev/packages/pi-vetter
- 9s demo GIF in the README