### PR TITLE
feat: add pi-verdict to Security & Permission

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -128,6 +128,7 @@ Security and permission control packages.
 - [pi-hooks/permission](https://github.com/prateekmedia/pi-hooks) - Four-tier permission control (Minimal/Low/Medium/High). `pi install npm:pi-hooks`
 - [filter-output](https://github.com/michalvavra/agents) - Automatically captures sensitive values and redacts them before sending to the AI. `pi install git:github.com/michalvavra/agents`
 - [security](https://github.com/michalvavra/agents) - Blocks dangerous commands (e.g., sudo) requiring explicit user approval. `pi install git:github.com/michalvavra/agents`
+- [pi-verdict](https://github.com/jesset/pi-verdict) - Claude Code auto-mode-style permission gate: three-state verdicts (allow/ask/deny), rule layer first with a context-aware classifier for the gray zone, fail-closed throughout; zero-dependency single file with a non-disableable self-protection layer. `pi install npm:pi-verdict`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ MCP (Model Context Protocol) 适配 Package，连接外部工具生态。
 - [pi-hooks/permission](https://github.com/prateekmedia/pi-hooks) - 四层权限控制（Minimal/Low/Medium/High）。`pi install npm:pi-hooks`
 - [filter-output](https://github.com/michalvavra/agents) - 自动捕获敏感值并在发送给 AI 前编辑。`pi install git:github.com/michalvavra/agents`
 - [security](https://github.com/michalvavra/agents) - 阻止危险命令（如 sudo），需要显式用户批准。`pi install git:github.com/michalvavra/agents`
+- [pi-verdict](https://github.com/jesset/pi-verdict) - Claude Code auto mode 式权限门禁：三态裁决（allow/ask/deny），规则层先行 + 携带会话上下文的分类器兜灰区，全链 fail-closed，零依赖单文件，含不可关闭的自保护层。`pi install npm:pi-verdict`
 
 ---
 


### PR DESCRIPTION
## 变更说明

在 **Security & Permission** 分类下新增 [pi-verdict](https://github.com/jesset/pi-verdict)（中英文 README 同步更新）：

- Claude Code auto mode 式权限门禁：三态裁决（allow / ask / deny）
- 规则层先行（内置 deny floor + 用户 allow/deny 规则），灰区交由携带会话上下文的模型分类器
- 全链 fail-closed；零依赖单文件；含不可关闭的自保护层（门禁自身文件仅用户可改，ADR-0001）
- 安装：\`pi install npm:pi-verdict\`

**收录状态**：已发布至 npm，并收录于 pi.dev 官方包目录：https://pi.dev/packages/pi-verdict

该条目填补了目录中「分类器式权限门禁」品类的空缺——现有 Security & Permission 条目均为静态规则/分层预设，无三态裁决 + 上下文分类器形态。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>