### PR TITLE
docs: 澄清 Pi 扩展的官方与社区归属

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -2,22 +2,22 @@ English | [中文](./README.md)
 
 # Awesome Pi [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
 
-> A curated list of [Pi Coding Agent](https://pi.dev) packages. Pi is a terminal AI coding harness by earendil-works with a thriving package ecosystem.
+> A community-maintained list of [Pi Coding Agent](https://pi.dev) packages. Pi is a terminal AI coding harness by earendil-works with a thriving package ecosystem. Most listed extensions, skills, and themes are published by community authors; inclusion does not imply an official Pi release or endorsement.
 
 [![Pi](https://img.shields.io/badge/Pi-v0.84+-blue.svg)](https://pi.dev)
 [![Packages](https://img.shields.io/badge/Packages-5500+-green.svg)](https://pi.dev/packages)
 [![License](https://img.shields.io/badge/License-CC0-lightgrey.svg)](https://creativecommons.org/publicdomain/zero/1.0/)
 
-[Pi Coding Agent](https://pi.dev) is an AI coding harness that supports Extensions, Skills, Themes, and Prompt Templates through its Package system. This list curates the best community packages to help developers build an efficient AI-powered coding environment.
+[Pi Coding Agent](https://pi.dev) is an AI coding harness that supports Extensions, Skills, Themes, and Prompt Templates through its Package system. This list curates community packages to help developers build an efficient AI-powered coding environment.
 
 ```
-# Install Pi AgentOS/Linux)
+# Install the Pi core CLI
 curl -fsSL https://pi.dev/install.sh | sh
 
-# Install a Pi Page
+# Install a community package (example)
 pi install npm:context-mode
 
-# List installed Pi Pages
+# List installed Pi packages
 pi list
 ```
 
@@ -57,7 +57,11 @@ pi list
 
 ## Packages
 
-> 🔵 **Official Packages**: Installed without `@scope` (e.g. `pi install npm:context-mode`). 🟢 **Community Packages**: Installed with `@scope` (e.g. `pi install npm:@narumitw/pi-statusline`), shown in `@scope/name` format.
+> **Package names and sources**: `npm:` only means installation from npm; both `name` and `@scope/name` can be community packages. An `@scope` is an npm namespace, and its presence or absence does not establish official Pi status. Use each project's full published package name and check its publisher and source repository. See [npm's scope documentation](https://docs.npmjs.com/about-scopes/).
+>
+> [pi.dev/packages](https://pi.dev/packages) is an ecosystem package catalog. Inclusion does not imply an official Pi release, review, or endorsement. The [Pi Package documentation](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/packages.md) explains npm / Git distribution and catalog discovery.
+>
+> Distinguish the [official Pi core](https://github.com/earendil-works/pi) (such as `@earendil-works/pi-coding-agent`), [upstream extension examples](https://github.com/earendil-works/pi/tree/main/packages/coding-agent/examples/extensions), and packages published independently by their authors. An official example of a feature does not make a community package implementing it an official release.
 
 ### Web Access & Search
 
@@ -87,7 +91,7 @@ MCP (Model Context Protocol) adapter packages for connecting to external tool ec
 
 Subagent packages for task delegation, parallel execution, and multi-agent orchestration.
 
-- 🔥 [pi-subagents](https://github.com/nicobailon/pi-subagents) - Official subagent extension with chain, parallel execution, and TUI clarification. `pi install npm:pi-subagents`
+- 🔥 [pi-subagents](https://github.com/nicobailon/pi-subagents) - Community subagent extension maintained by Nico Bailon (nicobailon), with chain, parallel execution, and TUI clarification. `pi install npm:pi-subagents`
 - 🔥 [@tintinweb/pi-subagents](https://github.com/tintinweb/pi-subagents) - Claude Code-style subagents with parallel background agents, real-time widgets, and Git worktree isolation. `pi install npm:@tintinweb/pi-subagents`
 - 🔥 [@gotgenes/pi-subagents](https://pi.dev/packages/@gotgenes/pi-subagents) - Friendly fork of tintinweb's subagents. `pi install npm:@gotgenes/pi-subagents`
 - [@narumitw/pi-subagents](https://github.com/narumiruna/pi-extensions) - Subagents with single/parallel/chain execution modes. `pi install npm:@narumitw/pi-subagents`
@@ -342,7 +346,7 @@ Theme collection packs — install multiple color schemes at once.
 
 Featured themes with unique design concepts and purposes.
 
-- 🔥 [pi-kanagawa](https://github.com/earendil-works/pi-kanagawa) - Inspired by Hokusai's "The Great Wave off Kanagawa", deep blue and warm gold with wave animations and git branch widgets. `pi install npm:pi-kanagawa`
+- 🔥 [pi-kanagawa](https://www.npmjs.com/package/pi-kanagawa) - Community theme published by williy_cole, inspired by Hokusai's "The Great Wave off Kanagawa", with deep blue and warm gold, wave animations, and git branch widgets. `pi install npm:pi-kanagawa`
 - [pi-terminal-theme](https://github.com/mavam/pi-terminal-theme) - Uses ANSI 0-15 colors, letting the terminal provide the actual colors. `pi install npm:pi-terminal-theme`
 - [pi-ansi-themes](https://github.com/leblancfg/pi-ansi-themes) - Standard 16-color ANSI themes to avoid conflicts with terminal themes. `pi install git:github.com/leblancfg/pi-ansi-themes`
 - [my-pi-themes/e-ink](https://pi.dev/packages/my-pi-themes) - E-ink friendly theme with high contrast and low color. `pi install npm:my-pi-themes`
@@ -398,12 +402,13 @@ Contributions are welcome! Here's how you can help:
 
 - Each entry should include name, link, description, and install command (where applicable)
 - Organize by functional category and maintain consistent formatting
-- Prefer resources with GitHub repositories or official documentation
+- Prefer resources with GitHub repositories or the project's own documentation
 - Include author information where available
+- Only label a resource as "official Pi" when its publisher and source repository support that attribution; do not infer it from installation method, scoped or unscoped names, or catalog inclusion
 
 ### npm Scope Migration Note
 
-On 2026-05-07, Pi migrated from `@mariozechner` to `@earendil-works` npm scope. Old packages are deprecated but will not be deleted. Run `pi update` to automatically migrate.
+Official Pi core npm packages have migrated from `@mariozechner` to `@earendil-works`. The table below lists core package renames, not a naming rule for community extensions. Each extension keeps the full package name specified by its publisher.
 
 | Old Package | New Package |
 |-------------|-------------|
@@ -423,4 +428,4 @@ This list is licensed under [CC0 1.0 Universal](https://creativecommons.org/publ
 
 ---
 
-*Last updated: August 2026. The Pi ecosystem is constantly evolving — check [pi.dev/packages](https://pi.dev/packages) for the latest.*
+*Last updated: September 2026 (source attribution revised; package selection and counts are from August 2026). The Pi ecosystem is constantly evolving — check [pi.dev/packages](https://pi.dev/packages) for the latest.*

--- a/README.md
+++ b/README.md
@@ -2,19 +2,19 @@
 
 # Awesome Pi [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
 
-> 精选 [Pi Coding Agent](https://pi.dev) Package 列表。Pi 是由 earendil-works 开发的终端 AI 编程助手，拥有丰富的 Package 生态。
+> 社区维护的 [Pi Coding Agent](https://pi.dev) Package 精选列表。Pi 是由 earendil-works 开发的终端 AI 编程助手，拥有丰富的 Package 生态。本列表收录的扩展、技能和主题主要由社区作者发布，收录不代表 Pi 官方发布或背书。
 
 [![Pi](https://img.shields.io/badge/Pi-v0.84+-blue.svg)](https://pi.dev)
 [![Packages](https://img.shields.io/badge/Packages-5500+-green.svg)](https://pi.dev/packages)
 [![License](https://img.shields.io/badge/License-CC0-lightgrey.svg)](https://creativecommons.org/publicdomain/zero/1.0/)
 
-[Pi Coding Agent](https://pi.dev) 是一个 AI Coding Harness 框架 Package 机制支持扩展（Extensions）、技能（Skills）、主题（Themes）和提示词模板（Prompt Templates）。本列表精选社区最佳 Package，帮助开发者打造高效的 AI 编程环境。
+[Pi Coding Agent](https://pi.dev) 是一个 AI Coding Harness 框架，其 Package 机制支持扩展（Extensions）、技能（Skills）、主题（Themes）和提示词模板（Prompt Templates）。本列表精选社区 Package，帮助开发者打造高效的 AI 编程环境。
 
 ```
-# 安装 Pi AgentOS/Linux)
+# 安装 Pi 核心 CLI
 curl -fsSL https://pi.dev/install.sh | sh
 
-# 安装 Pi ckage
+# 安装社区 Package（示例）
 pi install npm:context-mode
 
 # 查看已安装的 Pi Package
@@ -57,7 +57,11 @@ pi list
 
 ## Packages
 
-> 🔵 **官方 Package**：无需 `@scope` 即可安装的包（如 `pi install npm:context-mode`）。🟢 **社区 Package**：需带 `@scope` 安装的包（如 `pi install npm:@narumitw/pi-statusline`），列表中以 `@scope/name` 格式标注。
+> **包名与来源**：`npm:` 仅表示从 npm 安装；`name` 和 `@scope/name` 都可以是社区包名。`@scope` 是 npm 命名空间，有无 scope 都不能作为 Pi 官方身份的判断依据。请按各项目提供的完整包名安装，并核对发布者和源码仓库。参见 [npm scope 说明](https://docs.npmjs.com/about-scopes/)。
+>
+> [pi.dev/packages](https://pi.dev/packages) 是生态包目录，收录不代表 Pi 官方发布、审核或背书；[Pi Package 文档](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/packages.md) 说明了 npm / Git 分发方式和目录发现机制。
+>
+> [Pi 官方核心](https://github.com/earendil-works/pi)（如 `@earendil-works/pi-coding-agent`）、[上游扩展示例](https://github.com/earendil-works/pi/tree/main/packages/coding-agent/examples/extensions)与各作者独立发布的 Package 应分别看待。某个功能有官方示例，不代表实现该功能的社区包也是官方发布。
 
 ### Web Access & Search
 
@@ -87,7 +91,7 @@ MCP (Model Context Protocol) 适配 Package，连接外部工具生态。
 
 子代理 Package，支持任务委托、并行执行和多代理编排。
 
-- 🔥 [pi-subagents](https://github.com/nicobailon/pi-subagents) - 官方子代理扩展，支持链式、并行执行和 TUI 澄清。`pi install npm:pi-subagents`
+- 🔥 [pi-subagents](https://github.com/nicobailon/pi-subagents) - Nico Bailon（nicobailon）维护的社区子代理扩展，支持链式、并行执行和 TUI 澄清。`pi install npm:pi-subagents`
 - 🔥 [@tintinweb/pi-subagents](https://github.com/tintinweb/pi-subagents) - Claude Code 风格子代理，并行后台代理、实时 widget、Git worktree 隔离。`pi install npm:@tintinweb/pi-subagents`
 - 🔥 [@gotgenes/pi-subagents](https://pi.dev/packages/@gotgenes/pi-subagents) - tintinweb 的友好分支。`pi install npm:@gotgenes/pi-subagents`
 - [@narumitw/pi-subagents](https://github.com/narumiruna/pi-extensions) - 单/并行/链式执行模式的子代理。`pi install npm:@narumitw/pi-subagents`
@@ -342,7 +346,7 @@ Pi 核心不内置 plan mode，用扩展补只读规划。
 
 特色主题，独特的设计理念和用途。
 
-- 🔥 [pi-kanagawa](https://github.com/earendil-works/pi-kanagawa) - 受葛饰北斋《神奈川冲浪里》启发，深蓝色和温暖金色，含波浪动画和 git 分支小部件。`pi install npm:pi-kanagawa`
+- 🔥 [pi-kanagawa](https://www.npmjs.com/package/pi-kanagawa) - williy_cole 发布的社区主题，受葛饰北斋《神奈川冲浪里》启发，深蓝色和温暖金色，含波浪动画和 git 分支小部件。`pi install npm:pi-kanagawa`
 - [pi-terminal-theme](https://github.com/mavam/pi-terminal-theme) - 使用 ANSI 0-15 颜色的终端主题，让终端提供实际颜色。`pi install npm:pi-terminal-theme`
 - [pi-ansi-themes](https://github.com/leblancfg/pi-ansi-themes) - 标准 16 色 ANSI 主题，避免与终端主题冲突。`pi install git:github.com/leblancfg/pi-ansi-themes`
 - [my-pi-themes/e-ink](https://pi.dev/packages/my-pi-themes) - 电子墨水友好主题，高对比度低色彩。`pi install npm:my-pi-themes`
@@ -399,12 +403,13 @@ Pi 的 fork/替代发行版，提供开箱即用的增强体验。
 - 使用中文描述，保留英文名称和命令
 - 每个条目包含名称、链接、描述和安装命令（如果适用）
 - 按功能分类，保持格式一致
-- 优先选择有 GitHub 仓库或官方文档的资源
+- 优先选择有 GitHub 仓库或项目自身文档的资源
 - 标注作者信息（如有）
+- 仅在发布者和源码仓库可核实的情况下标注“Pi 官方”；不要根据安装方式、包名是否带 scope 或目录收录情况判断归属
 
 ### npm Scope 迁移说明
 
-2026-05-07，Pi 从 `@mariozechner` 迁移到 `@earendil-works` npm 作用域。旧包已弃用但不会被删除，运行 `pi update` 即可自动迁移。
+Pi 官方核心 npm 包已从 `@mariozechner` 迁移到 `@earendil-works`。下表列出的是核心包的命名变化，不是社区扩展的命名规则；各扩展仍使用其发布者指定的完整包名。
 
 | 旧包名 | 新包名 |
 |--------|--------|
@@ -424,6 +429,6 @@ Pi 的 fork/替代发行版，提供开箱即用的增强体验。
 
 ---
 
-*本文档最后更新于 2026 年 8 月。Pi 生态持续发展，建议定期查看 [pi.dev/packages](https://pi.dev/packages) 获取最新信息。*
+*本文档最后更新于 2026 年 9 月（来源说明修订；包选录和数量数据截至 2026 年 8 月）。Pi 生态持续发展，建议定期查看 [pi.dev/packages](https://pi.dev/packages) 获取最新信息。*
 
 <!-- END OF awesome-pi-list.md Part 2 -->

--- a/docs/research-new-packages-2026-08.md
+++ b/docs/research-new-packages-2026-08.md
@@ -4,6 +4,8 @@
 
 > **落地状态（2026-08-19）：** 建议入选已全部写入 `README.md` / `README.en.md`（含 6 个必加项、worktree / betterwright、第二梯队、补遗 `pi-sandbox` / `pi-interactive-shell`）。观察名单未进。
 
+> **来源勘误（2026-09-06）：** 本文的“官方目录”指 Pi 官网提供的生态包目录，不代表其中的包由 Pi 官方发布或背书。`npm:` 和包名是否带 `@scope` 均不能用于判断官方身份；`pi-subagents` 是 [Nico Bailon 维护的社区扩展](https://github.com/nicobailon/pi-subagents)。其余调研数据保留 2026-08-19 的时间边界。
+
 精选列表不是全量目录。官方目录约 5500+、npm `keywords:pi-package` 约 7788，绝大多数是主题、个人 fork、空壳 skill、第 N 个 todo。下面只推荐能对上现有 README 质量门槛的包。
 
 ## 1. 调研范围与截止点
@@ -69,7 +71,7 @@ Pi 核心故意不内置 MCP、sub-agent、权限弹窗、plan mode、todo、后
 | 作者 | narumiruna / `@narumitw`（列表已收录其 statusline / lsp / goal / subagents） |
 | 首次发布 / 最近发布 | 2026-05-17 / 2026-08-05，v0.49.3，72 个版本，MIT |
 | 仓库 | https://github.com/narumiruna/pi-extensions/tree/main/packages/pi-plan-mode |
-| npm / 官方页 | https://www.npmjs.com/package/@narumitw/pi-plan-mode · https://pi.dev/packages/@narumitw/pi-plan-mode |
+| npm / Pi 目录页 | https://www.npmjs.com/package/@narumitw/pi-plan-mode · https://pi.dev/packages/@narumitw/pi-plan-mode |
 | 月下载 | 19,389 |
 | 实现信号 | 包内 47 个文件、15 个测试 |
 | 一句话能力 | Codex 风格只读 `/plan`：探索、澄清、产出可实施计划后再改代码。 |
@@ -89,7 +91,7 @@ README 原文：Pi 核心故意不内置 plan mode；本包补上。默认启用
 | 首次发布 / 最近发布 | 2026-05-30 / 2026-08-16，v3.6.0，51 个版本，MIT |
 | 仓库 | https://github.com/QuintinShaw/pi-dynamic-workflows（427★） |
 | 文档站 | https://quintinshaw.github.io/pi-dynamic-workflows/ |
-| npm / 官方页 | https://www.npmjs.com/package/@quintinshaw/pi-dynamic-workflows · https://pi.dev/packages/@quintinshaw/pi-dynamic-workflows |
+| npm / Pi 目录页 | https://www.npmjs.com/package/@quintinshaw/pi-dynamic-workflows · https://pi.dev/packages/@quintinshaw/pi-dynamic-workflows |
 | 月下载 | 27,843 |
 | 实现信号 | 仓库约 179 blob、`tests/` 下数十个单测 |
 | 一句话能力 | 把一次请求写成 JS 编排，扇出到隔离子代理，按任务路由模型并交叉校验。 |
@@ -106,7 +108,7 @@ README：`agent()` / `parallel()` / `pipeline()` / `phase()`；中间结果留�
 | 作者 | monotykamary |
 | 首次发布 / 最近发布 | **2026-07-13** / 2026-08-17，v0.61.2，200 个版本，MIT |
 | 仓库 | https://github.com/monotykamary/pi-fabric（124★，有 `.github/workflows/test.yml`） |
-| npm / 官方页 | https://www.npmjs.com/package/pi-fabric · https://pi.dev/packages/pi-fabric |
+| npm / Pi 目录页 | https://www.npmjs.com/package/pi-fabric · https://pi.dev/packages/pi-fabric |
 | 月下载 | 32,966 |
 | 实现信号 | 约 500 blob、大量 `tests/*.test.ts` |
 | 一句话能力 | 可编程工具运行时：在受检 TypeScript 里编排核心工具、MCP、agent 与工作流。 |
@@ -123,7 +125,7 @@ README：一个 `fabric_exec` 工具；默认跑在 QuickJS；支持 one-shot / 
 | 作者 | juicesharp（列表已收录 rpiv-todo / web-tools / advisor / ask-user 等） |
 | 首次发布 / 最近发布 | 2026-05-11 / 2026-08-18，v2.6.2，51 个版本，MIT |
 | 仓库 | https://github.com/juicesharp/rpiv-mono/tree/main/packages/rpiv-voice |
-| npm / 官方页 | https://www.npmjs.com/package/@juicesharp/rpiv-voice · https://pi.dev/packages/@juicesharp/rpiv-voice |
+| npm / Pi 目录页 | https://www.npmjs.com/package/@juicesharp/rpiv-voice · https://pi.dev/packages/@juicesharp/rpiv-voice |
 | 月下载 | 21,118 |
 | 实现信号 | 包内 88 个文件、29 个 `*.test.ts`（mic / STT / hallucination filter / command） |
 | 一句话能力 | `/voice` 本机 Whisper 听写，无云、无 API key。 |
@@ -141,7 +143,7 @@ README：overlay 听写；sherpa-onnx Whisper base multilingual int8；首次下
 | 首次发布 / 最近发布 | 2026-05-09 / 2026-08-11，v1.202608.1，28 个版本，MIT |
 | 仓库 | https://github.com/jmfederico/pi-web（567★，watch=3，forks=114，有 CI） |
 | 站点 | https://pi-web.dev/ |
-| npm / 官方页 | https://www.npmjs.com/package/@jmfederico/pi-web · https://pi.dev/packages/@jmfederico/pi-web |
+| npm / Pi 目录页 | https://www.npmjs.com/package/@jmfederico/pi-web · https://pi.dev/packages/@jmfederico/pi-web |
 | 月下载 | 7,866 |
 | 一句话能力 | 浏览器监督跑在真实工作区里的 Pi 会话，断线不杀进程。 |
 | 安装 | `pi install npm:@jmfederico/pi-web`（也支持 `npm i -g @jmfederico/pi-web` + `pi-web install`） |
@@ -173,7 +175,7 @@ README：就绪标记 / 错误 / 退出会把 Pi 拉回对话；`/ps`、`/ps:log
 | 作者 | narumiruna |
 | 首次发布 / 最近发布 | **2026-07-21** / 2026-08-18，v0.51.2，22 个版本，MIT |
 | 仓库 | https://github.com/narumiruna/pi-extensions/tree/main/packages/pi-worktree |
-| npm / 官方页 | https://www.npmjs.com/package/@narumitw/pi-worktree · https://pi.dev/packages/@narumitw/pi-worktree |
+| npm / Pi 目录页 | https://www.npmjs.com/package/@narumitw/pi-worktree · https://pi.dev/packages/@narumitw/pi-worktree |
 | 月下载 | 3,629 |
 | 实现信号 | 包内 23 个文件、11 个测试 |
 | 一句话能力 | 交互式 Git worktree：创建 / 切换 / 删除，并把 Pi 会话带到新工作区。 |
@@ -190,7 +192,7 @@ README 点出真实缺口：Pi 不能 `cd` 改父进程工作目录。本包用�
 | 作者 | BetterWright / curiosityos |
 | 首次发布 / 最近发布 | **2026-07-14** / 2026-08-19，v1.9.6，53 个版本，MIT |
 | 仓库 | https://github.com/BetterWright/betterwright（114★，有 CI / `release:check`） |
-| npm / 官方页 | https://www.npmjs.com/package/betterwright · https://pi.dev/packages/betterwright |
+| npm / Pi 目录页 | https://www.npmjs.com/package/betterwright · https://pi.dev/packages/betterwright |
 | 月下载 | 8,993 |
 | 实现信号 | `package.json` 含 `pi.extensions`；约 76 个测试相关文件；`prepublishOnly` 跑 lint + typecheck + unit |
 | 一句话能力 | 持久、策略守卫的 Playwright：网络策略、凭证保险库、证明截图。 |
@@ -333,7 +335,7 @@ README：压缩 snapshot 而不是整页 HTML；会话跨回合保持；同时�
 ## 7. 明确不推荐（这次）
 
 - **纯主题 / 欢迎屏 / 节日皮肤**：`sort=recent` 里大量当日主题。现有 Featured/Tools 门槛是「设计理念独特」（kanagawa / theme-sync），新主题默认不进。
-- **subagent 第 5、第 6 个 fork**（`@lpb-work/*`、`@ferris1225/*`、`wj-pi-subagents`）。列表已有官方 `pi-subagents`、tintinweb、gotgenes、narumitw、interactive、roach-pi。
+- **subagent 第 5、第 6 个 fork**（`@lpb-work/*`、`@ferris1225/*`、`wj-pi-subagents`）。列表已有 Nico Bailon 的社区包 `pi-subagents`、tintinweb、gotgenes、narumitw、interactive、roach-pi。
 - **包名带 personal、无仓库、无 README 的 npm 包**。
 - **用异常 star 当唯一质量信号**（`ponytail`：10.5 万★ vs 255 watch）。
 - **只把已收录包再发一个 scope**。


### PR DESCRIPTION
README 之前按 npm 包名是否带 `@scope` 区分官方与社区，并将 `pi-subagents` 标为官方扩展。这会让读者把安装方式或目录收录误认为 Pi 官方发布。现在中英文 README 明确说明：`npm:` 仅代表安装来源，scope 是命名空间，归属需要核对发布者及源码仓库；同时区分官方核心、上游扩展示例与各作者独立发布的 Package。

同步更正 `pi-subagents` 的社区作者归属，以及 `pi-kanagawa` 误指向官方组织的链接和发布者信息；在贡献规范中加入来源核实要求，并修正历史调研文档中的相同误述。文档注明本次为来源说明修订，包选录和数量仍保留 2026 年 8 月的时间边界。

验证：
- `git diff --check` 和 `git diff --cached --check` 通过。
- 中英文 README 各自保留原有 144 个条目、143 条安装命令；条目名称与顺序一致。
- 检查 3 份文档中的已知错误归属表述、目录标签及 Markdown 代码围栏。
- 归属与安装机制已对照上游 Package 文档、npm scope 文档、npm registry 和 GitHub 仓库核实。

依据：[Pi Package 文档](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/packages.md)、[npm scope 说明](https://docs.npmjs.com/about-scopes/)、[pi-subagents](https://github.com/nicobailon/pi-subagents)、[pi-kanagawa 发布信息](https://registry.npmjs.org/pi-kanagawa/latest)。
