### PR TITLE
Add @dingdinglz/pi-worktree to Task Management

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -213,6 +213,7 @@ Task management and goal tracking packages.
 - [pi-agent-flow](https://pi.dev/packages/pi-agent-flow) - Agent workflow orchestration tool. `pi install npm:pi-agent-flow`
 - [@gonrocca/zero-pi](https://pi.dev/packages/@gonrocca/zero-pi) - Spec-driven development workflow (explore→plan→build→verify). `pi install npm:@gonrocca/zero-pi`
 - [@narumitw/pi-worktree](https://github.com/narumiruna/pi-extensions) - Interactive Git worktrees: create, switch, remove, and move the Pi session into the new workspace. `pi install npm:@narumitw/pi-worktree`
+- [@dingdinglz/pi-worktree](https://github.com/dingdinglz/pi-worktree) - Git worktree workflows for Pi with verified PR publishing and resumable merges back to the original checkout. `pi install git:github.com/dingdinglz/pi-worktree`
 
 ---
 

--- a/README.en.md
+++ b/README.en.md
@@ -213,7 +213,7 @@ Task management and goal tracking packages.
 - [pi-agent-flow](https://pi.dev/packages/pi-agent-flow) - Agent workflow orchestration tool. `pi install npm:pi-agent-flow`
 - [@gonrocca/zero-pi](https://pi.dev/packages/@gonrocca/zero-pi) - Spec-driven development workflow (explore→plan→build→verify). `pi install npm:@gonrocca/zero-pi`
 - [@narumitw/pi-worktree](https://github.com/narumiruna/pi-extensions) - Interactive Git worktrees: create, switch, remove, and move the Pi session into the new workspace. `pi install npm:@narumitw/pi-worktree`
-- [@dingdinglz/pi-worktree](https://github.com/dingdinglz/pi-worktree) - Git worktree workflows for Pi with verified PR publishing and resumable merges back to the original checkout. `pi install git:github.com/dingdinglz/pi-worktree`
+- [@dinglz/pi-worktree](https://github.com/dingdinglz/pi-worktree) - Git worktree workflows for Pi with verified PR publishing and resumable merges back to the original checkout. `pi install npm:@dinglz/pi-worktree`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ MCP (Model Context Protocol) 适配 Package，连接外部工具生态。
 - [pi-agent-flow](https://pi.dev/packages/pi-agent-flow) - Agent 工作流编排工具。`pi install npm:pi-agent-flow`
 - [@gonrocca/zero-pi](https://pi.dev/packages/@gonrocca/zero-pi) - 规范驱动开发工作流（探索→计划→构建→验证）。`pi install npm:@gonrocca/zero-pi`
 - [@narumitw/pi-worktree](https://github.com/narumiruna/pi-extensions) - 交互式 Git worktree：创建 / 切换 / 删除，并把 Pi 会话切到新工作区。`pi install npm:@narumitw/pi-worktree`
+- [@dingdinglz/pi-worktree](https://github.com/dingdinglz/pi-worktree) - 面向 Pi 的 Git worktree 工作流：隔离开发、校验 PR 发布结果，并支持恢复中断流程、合并回原工作目录。`pi install git:github.com/dingdinglz/pi-worktree`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ MCP (Model Context Protocol) 适配 Package，连接外部工具生态。
 - [pi-agent-flow](https://pi.dev/packages/pi-agent-flow) - Agent 工作流编排工具。`pi install npm:pi-agent-flow`
 - [@gonrocca/zero-pi](https://pi.dev/packages/@gonrocca/zero-pi) - 规范驱动开发工作流（探索→计划→构建→验证）。`pi install npm:@gonrocca/zero-pi`
 - [@narumitw/pi-worktree](https://github.com/narumiruna/pi-extensions) - 交互式 Git worktree：创建 / 切换 / 删除，并把 Pi 会话切到新工作区。`pi install npm:@narumitw/pi-worktree`
-- [@dingdinglz/pi-worktree](https://github.com/dingdinglz/pi-worktree) - 面向 Pi 的 Git worktree 工作流：隔离开发、校验 PR 发布结果，并支持恢复中断流程、合并回原工作目录。`pi install git:github.com/dingdinglz/pi-worktree`
+- [@dinglz/pi-worktree](https://github.com/dingdinglz/pi-worktree) - 面向 Pi 的 Git worktree 工作流：隔离开发、校验 PR 发布结果，并支持恢复中断流程、合并回原工作目录。`pi install npm:@dinglz/pi-worktree`
 
 ---
 


### PR DESCRIPTION
我是 [pi-worktree](https://github.com/dingdinglz/pi-worktree) 的维护者。本 PR 将 `@dingdinglz/pi-worktree` 加入 **Task Management**，同步更新中英文 README，包含项目链接、简短说明和 Git 安装命令。

这个 Pi 扩展记录创建 worktree 时的原始 checkout 和分支，支持 agent 辅助的 PR 发布与本地合并。发布前需要用户审核，清理前校验远端提交与 PR 状态，中断的收尾流程可以恢复。它与已有的 `@narumitw/pi-worktree` 是不同作者的项目，因此条目使用完整包名区分。

安装：`pi install git:github.com/dingdinglz/pi-worktree`

验证：
- `bun run validate`：20 个现有测试通过，Astro 检查无错误或警告，静态构建成功
- `git diff --check`
- 中英文条目的名称、URL、分类和安装命令一致
- 两个语言页面的构建产物均包含新增项目链接和安装命令
