### PR TITLE
feat: 接入 Vercel Web Analytics

### DIFF
--- a/docs/website.md
+++ b/docs/website.md
@@ -62,6 +62,16 @@ bun run --cwd site preview
 
 分支验证通过后再合入 `main`。后续只需通过 PR 修改 README，合并后 Vercel 即会重新生成网站。
 
+## 访问统计
+
+网站通过 `@vercel/analytics/astro` 接入 Vercel Web Analytics，在中英文共用的 `Directory.astro` 中加载一次。英文 `/` 和中文 `/zh/` 分别记录浏览量，可在 Vercel 控制台查看访客、浏览量、来源、国家/地区和设备等基础数据。
+
+首次启用时，在 Vercel 的 **awesome-pi** 项目（域名 `awesome-pi-list.vercel.app`）中进入 **Analytics**，点击 **Enable**（如果尚未启用），然后重新部署包含此改动的版本。部署后访问网站，再到 Analytics 查看数据；仅安装包和本地验证不会使线上统计生效。
+
+开发服务器使用 SDK 的开发模式，不发送正式统计数据；生产构建使用正式统计脚本。当前只接入基础页面访问统计，没有添加搜索、复制或点击等自定义事件。
+
+接入和排查步骤见 [Vercel Web Analytics 官方指南](https://vercel.com/docs/analytics/quickstart)。
+
 ## 视觉验收
 
 交付时在真实浏览器中检查英文、中文、搜索、分类、复制结果、分享链接与空结果状态。至少检查桌面和手机尺寸，确认没有页面横向溢出，并提供截图。截图保存在被 Git 忽略的 `output/playwright/`。

--- a/site/bun.lock
+++ b/site/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "awesome-pi-site",
       "dependencies": {
+        "@vercel/analytics": "2.0.1",
         "astro": "7.3.1",
         "mdast-util-to-string": "4.0.0",
         "remark-parse": "11.0.0",
@@ -299,6 +300,8 @@
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.4.0", "", {}, "sha512-1mEZtMKPM09vDmQt5y7YvmN2+DFTP7Tg0EWXdic8/C6VRnpb33e4ghisCIE3WZjsE2N8mf+QV1Zqh7ZFYLWInQ=="],
+
+    "@vercel/analytics": ["@vercel/analytics@2.0.1", "", { "peerDependencies": { "@remix-run/react": "^2", "@sveltejs/kit": "^1 || ^2", "next": ">= 13", "nuxt": ">= 3", "react": "^18 || ^19 || ^19.0.0-rc", "svelte": ">= 4", "vue": "^3", "vue-router": "^4" }, "optionalPeers": ["@remix-run/react", "@sveltejs/kit", "next", "nuxt", "react", "svelte", "vue", "vue-router"] }, "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g=="],
 
     "@volar/kit": ["@volar/kit@2.4.28", "", { "dependencies": { "@volar/language-service": "2.4.28", "@volar/typescript": "2.4.28", "typesafe-path": "^0.2.2", "vscode-languageserver-textdocument": "^1.0.11", "vscode-uri": "^3.0.8" }, "peerDependencies": { "typescript": "*" } }, "sha512-cKX4vK9dtZvDRaAzeoUdaAJEew6IdxHNCRrdp5Kvcl6zZOqb6jTOfk3kXkIkG3T7oTFXguEMt5+9ptyqYR84Pg=="],
 

--- a/site/package.json
+++ b/site/package.json
@@ -13,6 +13,7 @@
     "validate": "bun run test && bun run check && bun run build && bun run test:rendered"
   },
   "dependencies": {
+    "@vercel/analytics": "2.0.1",
     "astro": "7.3.1",
     "mdast-util-to-string": "4.0.0",
     "remark-parse": "11.0.0",

--- a/site/src/components/Directory.astro
+++ b/site/src/components/Directory.astro
@@ -1,4 +1,5 @@
 ---
+import Analytics from '@vercel/analytics/astro';
 import { createCatalog, type Locale } from '../lib/catalog';
 import englishReadme from '../../../README.en.md?raw';
 import chineseReadme from '../../../README.md?raw';
@@ -137,5 +138,6 @@ const categoryUrl = (id: string) => `${base}?category=${id}`;
       import { initializeDirectory } from '../scripts/directory';
       initializeDirectory(document, window);
     </script>
+    <Analytics />
   </body>
 </html>

--- a/site/tests/rendered.test.ts
+++ b/site/tests/rendered.test.ts
@@ -5,6 +5,18 @@ import { loadCatalog } from '../src/lib/catalog';
 
 describe('generated static pages', () => {
   for (const [locale, path] of [['en', '../dist/index.html'], ['zh', '../dist/zh/index.html']] as const) {
+    test(`${locale} includes exactly one analytics tracker for its page route`, () => {
+      const win = new Window();
+      try {
+        win.document.write(readFileSync(new URL(path, import.meta.url), 'utf8'));
+        const trackers = win.document.querySelectorAll('vercel-analytics');
+        expect(trackers).toHaveLength(1);
+        expect(trackers[0]?.getAttribute('data-pathname')).toBe(locale === 'zh' ? '/zh/' : '/');
+      } finally {
+        win.happyDOM.abort();
+      }
+    });
+
     test(`${locale} contains the full directory and accessible controls before JavaScript runs`, () => {
       const html = readFileSync(new URL(path, import.meta.url), 'utf8');
       const win = new Window();


### PR DESCRIPTION
为中英文静态目录接入 Vercel Web Analytics，使用共享页面中的官方 Astro 组件统计页面访问。新增 `@vercel/analytics@2.0.1`，补充两种语言页面的统计组件与路由检查，并记录控制台启用和部署步骤。

验证：`bun run --cwd site validate` 通过，共 22 项测试，Astro 类型检查和静态构建无错误。Vercel 生产部署通过相同验证，统计服务已记录测试访问。
